### PR TITLE
Fix practice_5.8 output

### DIFF
--- a/practice_5.8/test_case_1/output
+++ b/practice_5.8/test_case_1/output
@@ -4,13 +4,11 @@
 /boot
 /boot/efi
 /run/user/1000
-/media/a/CDROM
-/media/a/Ubuntu
-50-75
 /dev/shm
+50-75
 75-85
-
 85-95
 /
 >95
-
+/media/a/CDROM
+/media/a/Ubuntu 22.04 LTS amd64


### PR DESCRIPTION
The output of practice_5.8 assignment was wrong as per problem statement, this PR fixes it.