### PR TITLE
Fix the ordering of output inside a group according to the input order

### DIFF
--- a/practice_5.8/test_case_1/output
+++ b/practice_5.8/test_case_1/output
@@ -1,10 +1,10 @@
 0-50
 /run
+/dev/shm
 /run/lock
 /boot
 /boot/efi
 /run/user/1000
-/dev/shm
 50-75
 75-85
 85-95

--- a/practice_5.9/test_case_1/output
+++ b/practice_5.9/test_case_1/output
@@ -1,10 +1,10 @@
 0-50
 /run
+/dev/shm
 /run/lock
 /boot
 /boot/efi
 /run/user/1000
-/dev/shm
 85-95
 /
 >95


### PR DESCRIPTION
The input file has /dev/shm after /run and before /run/lock, so the output should also be in that order.